### PR TITLE
Add support for using specific kernel release

### DIFF
--- a/gen_stap.sh
+++ b/gen_stap.sh
@@ -162,6 +162,7 @@ if [ -z "$calls" ];then
   returns="probe kernel.function(\"*\").return?"
 fi
 
+echo "[+] Kernel release: $kernel_release"
 echo "[+] Entry func: $probe"
 echo "[+] Inject modules: $modules"
 echo "[+] Inject kernel funcs: $kfuncs"


### PR DESCRIPTION
This patch adds support for explicitly specifying the kernel release to be used, through a dedicated command-line argument. The `-r, --release` flag has been introduced for this purpose. It requires a string argument in the format of a kernel release (e.g. `5.3.0-45-generic`, generally the same format as output by `uname -r`).

The `gen_stap.sh` script will assume the kernel release to be the output of `uname -r` in case no explicit release is given at the command line.

Two additional checks have been performed to validate the input release against the filesystem.